### PR TITLE
feat: add oraclePrice and goverance data to liquidated vaults

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -139,6 +139,11 @@ type Vault @entity {
   wallet: Wallet!
 }
 
+type VaultManagerGovernanceJson @jsonField {
+  liquidationMarginDenominator: BigInt
+  liquidationMarginNumerator: BigInt
+}
+
 type VaultLiquidation @entity {
   id: ID!
   blockHeight: BigInt!
@@ -152,6 +157,7 @@ type VaultLiquidation @entity {
   wallet: Wallet!
   currentState: Vault!
   liquidatingState: VaultLiquidation!
+  vaultManagerGovernance: VaultManagerGovernanceJson
 }
 
 type VaultManagerMetrics @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -144,6 +144,11 @@ type VaultManagerGovernanceJson @jsonField {
   liquidationMarginNumerator: BigInt
 }
 
+type OraclePriceJson @jsonField {
+  typeInAmount: BigInt
+  typeOutAmount: BigInt
+}
+
 type VaultLiquidation @entity {
   id: ID!
   blockHeight: BigInt!
@@ -158,6 +163,7 @@ type VaultLiquidation @entity {
   currentState: Vault!
   liquidatingState: VaultLiquidation!
   vaultManagerGovernance: VaultManagerGovernanceJson
+  oraclePrice: OraclePriceJson
 }
 
 type VaultManagerMetrics @entity {

--- a/src/mappings/events/vaults.ts
+++ b/src/mappings/events/vaults.ts
@@ -93,7 +93,12 @@ export const vaultsEventKit = (block: any, data: any, module: string, path: stri
       );
     }
 
-    const vaultGovernanceId = id.split('.').slice(0, 4).join('.') + '.governance';
+    const pathRegex = /^(published\.vaultFactory\.managers\.manager[0-9]+)\.vaults\.vault[0-9]+$/
+    const pathRegexMatch = path.match(pathRegex);
+    if (!pathRegexMatch) {
+      throw new Error('path format is invalid');
+    }
+    const vaultGovernanceId = pathRegexMatch[1] + '.governance';
     const vaultManagerGovernance = await VaultManagerGovernance.get(vaultGovernanceId);
 
     const oraclPriceId = `${denom}-USD`;

--- a/src/mappings/events/vaults.ts
+++ b/src/mappings/events/vaults.ts
@@ -89,6 +89,16 @@ export const vaultsEventKit = (block: any, data: any, module: string, path: stri
       );
     }
 
+    const vaultGovernanceId = id.split('.').slice(0, 4).join('.') + '.governance';
+    const vaultManagerGovernance = await VaultManagerGovernance.get(vaultGovernanceId);
+
+    if (vaultManagerGovernance && payload?.vaultState === 'liquidated' && vault.vaultManagerGovernance === undefined) {
+      vault.vaultManagerGovernance = {
+        liquidationMarginNumerator: vaultManagerGovernance?.liquidationMarginNumerator,
+        liquidationMarginDenominator: vaultManagerGovernance?.liquidationMarginDenominator,
+      };
+    }
+
     vault.coin = payload?.locked?.__brand;
     vault.denom = payload?.locked?.__brand;
     vault.debt = payload?.debtSnapshot?.debt?.__value;

--- a/src/mappings/events/vaults.ts
+++ b/src/mappings/events/vaults.ts
@@ -99,19 +99,17 @@ export const vaultsEventKit = (block: any, data: any, module: string, path: stri
     const oraclPriceId = `${denom}-USD`;
     const oraclePrice = await OraclePrice.get(oraclPriceId);
 
-    if (payload?.vaultState === 'liquidated') {
-      if (vaultManagerGovernance && vault.vaultManagerGovernance === undefined)
-        vault.vaultManagerGovernance = {
-          liquidationMarginNumerator: vaultManagerGovernance.liquidationMarginNumerator,
-          liquidationMarginDenominator: vaultManagerGovernance.liquidationMarginDenominator,
-        };
+    if (vaultManagerGovernance && vault.vaultManagerGovernance === undefined)
+      vault.vaultManagerGovernance = {
+        liquidationMarginNumerator: vaultManagerGovernance.liquidationMarginNumerator,
+        liquidationMarginDenominator: vaultManagerGovernance.liquidationMarginDenominator,
+      };
 
-      if (oraclePrice && vault.oraclePrice === undefined)
-        vault.oraclePrice = {
-          typeInAmount: oraclePrice.typeInAmount,
-          typeOutAmount: oraclePrice.typeOutAmount,
-        };
-    }
+    if (oraclePrice && vault.oraclePrice === undefined)
+      vault.oraclePrice = {
+        typeInAmount: oraclePrice.typeInAmount,
+        typeOutAmount: oraclePrice.typeOutAmount,
+      };
 
     vault.coin = denom;
     vault.denom = denom;


### PR DESCRIPTION
This PR adds a snapshot of the `vaultManagerGovernance` and the `oraclePrice` at the time that a vault is liquidated. the reason for doing this is that we need to display the data at the time of liquidation in order to be accurate

example data of both a liquidated and liquidating vaults:
![image](https://github.com/Agoric/agoric-subql/assets/8860764/c13f4d08-cf98-42c7-84ef-81884f6458f0)
