### PR TITLE
test: remove flaky expected values

### DIFF
--- a/scripts/queries.mjs
+++ b/scripts/queries.mjs
@@ -176,12 +176,10 @@ export const expectations = {
     id: 'IST',
     denom: 'IST',
     key: 'Fee',
-    value: '192790171',
   },
   reserveAllocationMetricsDailies: {
     denom: 'IST',
     key: 'Fee',
-    valueLast: '192790171',
     metricsCount: '1',
   },
 };


### PR DESCRIPTION
The PR temporarily removes the `value` field from `reserveAllocationMetrics` and the `valueLast` field from `reserveAllocationMetricsDailies` expected values.