### PR TITLE
fix: remove FastUsdcTransactionStatus indexing

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -330,7 +330,7 @@ type FastUsdcTransaction @entity {
   sourceAddress: String! @index
   eud: String!
   usdcAmount: BigInt!
-  status: FastUsdcTransactionStatus! @index
+  status: FastUsdcTransactionStatus!
   contractFee: BigInt
   poolFee: BigInt
 }


### PR DESCRIPTION
Trying to upgrade staging with indexing enabled failed on the staging environment. I haven't tried reproducing this in the local environment.
After removing the indexing, the upgrade on staging worked.
I am not sure how important status indexing is here. If it is important, then we should investigate further. 
We should also upgrade the use of subql stack which might be all we need. Currently, we are using an older version of subql-node-cosmos:v4.2.1 and subql-query:v2.19.0. 