### PR TITLE
fix(indexer): Add !vaultId check

### DIFF
--- a/src/mappings/events/vaults.ts
+++ b/src/mappings/events/vaults.ts
@@ -47,6 +47,8 @@ export const vaultsEventKit = (block: CosmosBlock, data: StreamCell, module: str
       for (let i = 0; i < payload.offerToPublicSubscriberPaths.length; i++) {
         const [_, { vault: vaultId }] = payload.offerToPublicSubscriberPaths[i] as [string, { vault: string }];
 
+        if (!vaultId)
+          continue
         let vault = await Vault.get(vaultId);
         if (!vault) {
           vault = new Vault(vaultId, BigInt(data.blockHeight), block.block.header.time as Date, wallet.id);


### PR DESCRIPTION
Technically, we need to evaluate the need of code for `Vault` creation here and remove it completely.
This should be part of sunset IST but I guess we missed it. 

But for now, I've added a safety check to make the indexer up again.


